### PR TITLE
Updates the legacy StdPeriph library for various STM32 families.

### DIFF
--- a/generators/stm32/DeviceListProvider.cs
+++ b/generators/stm32/DeviceListProvider.cs
@@ -419,7 +419,7 @@ namespace stm32_bsp_generator
 
                     for (int i = 0; i < cores.Length; i++)
                     {
-                        if (db.STM32CubeTimestamp == 133047056504658633 && m.GetAttribute("Name").StartsWith("STM32MP13"))
+                        if ((db.STM32CubeTimestamp == 133047056504658633 || db.STM32CubeTimestamp == 133310388898546160) && m.GetAttribute("Name").StartsWith("STM32MP13"))
                             continue;
 
                         lstMCUs.Add(new ParsedMCU(m, familyDir, db, cores, i));

--- a/generators/stm32/rules/classic/Families/stm32f0.xml
+++ b/generators/stm32/rules/classic/Families/stm32f0.xml
@@ -73,7 +73,7 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F0xx_StdPeriph_Lib_V1.5.0\Libraries\STM32F0xx_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F0xx_StdPeriph_Lib_V1.6.0\Libraries\STM32F0xx_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 					<Patches>
 						<Patch xsi:type="InsertLines">
@@ -86,7 +86,7 @@
 					</Patches>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F0xx_StdPeriph_Lib_V1.5.0\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F0xx_StdPeriph_Lib_V1.6.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>

--- a/generators/stm32/rules/classic/Families/stm32f1.xml
+++ b/generators/stm32/rules/classic/Families/stm32f1.xml
@@ -69,11 +69,11 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F10x_StdPeriph_Lib_V3.5.0\Libraries\STM32F10x_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F10x_StdPeriph_Lib_V3.6.0\Libraries\STM32F10x_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F10x_StdPeriph_Lib_V3.5.0\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F10x_StdPeriph_Lib_V3.6.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>

--- a/generators/stm32/rules/classic/Families/stm32f2.xml
+++ b/generators/stm32/rules/classic/Families/stm32f2.xml
@@ -31,11 +31,11 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F2xx_StdPeriph_Lib_V1.1.0\Libraries\STM32F2xx_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F2xx_StdPeriph_Lib_V1.2.0\Libraries\STM32F2xx_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F2xx_StdPeriph_Lib_V1.1.0\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F2xx_StdPeriph_Lib_V1.2.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros></PreprocessorMacros>

--- a/generators/stm32/rules/classic/Families/stm32f3.xml
+++ b/generators/stm32/rules/classic/Families/stm32f3.xml
@@ -59,7 +59,7 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F30x_DSP_StdPeriph_Lib_V1.2.3\Libraries\STM32F30x_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F30x_DSP_StdPeriph_Lib_V1.3.0\Libraries\STM32F30x_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 					<Patches>
 						<Patch xsi:type="InsertLines">
@@ -72,7 +72,7 @@
 					</Patches>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F30x_DSP_StdPeriph_Lib_V1.2.3\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F30x_DSP_StdPeriph_Lib_V1.3.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.bspoptions.primary_memory$$_layout;$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>
@@ -110,11 +110,11 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F37x_DSP_StdPeriph_Lib_V1.0.0\Libraries\STM32F37x_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F37x_DSP_StdPeriph_Lib_V1.1.0\Libraries\STM32F37x_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F37x_DSP_StdPeriph_Lib_V1.0.0\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F37x_DSP_StdPeriph_Lib_V1.1.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>Device\*.h;Device\*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>

--- a/generators/stm32/rules/classic/Families/stm32f4.xml
+++ b/generators/stm32/rules/classic/Families/stm32f4.xml
@@ -73,7 +73,7 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F4xx_DSP_StdPeriph_Lib_V1.8.0\Libraries\STM32F4xx_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F4xx_DSP_StdPeriph_Lib_V1.9.0\Libraries\STM32F4xx_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 					<ProjectInclusionMask>-*stm32f4xx_fmc.c;*</ProjectInclusionMask>
 					<SimpleFileConditions>
@@ -107,7 +107,7 @@
 				</Patches>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F4xx_DSP_StdPeriph_Lib_V1.8.0\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32F4xx_DSP_StdPeriph_Lib_V1.9.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>

--- a/generators/stm32/rules/classic/Families/stm32l1.xml
+++ b/generators/stm32/rules/classic/Families/stm32l1.xml
@@ -53,11 +53,11 @@
 			<DefaultEnabled>false</DefaultEnabled>
 			<CopyJobs>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32L1xx_StdPeriph_Lib_V1.3.1\Libraries\STM32L1xx_StdPeriph_Driver</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32L1xx_StdPeriph_Lib_V1.4.0\Libraries\STM32L1xx_StdPeriph_Driver</SourceFolder>
 					<FilesToCopy>*.c;*.h</FilesToCopy>
 				</CopyJob>
 				<CopyJob>
-					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32L1xx_StdPeriph_Lib_V1.3.1\Libraries\CMSIS</SourceFolder>
+					<SourceFolder>$$BSPGEN:INPUT_DIR$$\Legacy\STM32L1xx_StdPeriph_Lib_V1.4.0\Libraries\CMSIS</SourceFolder>
 					<TargetFolder>CMSIS_StdPeriph</TargetFolder>
 					<FilesToCopy>-DSP_Lib\*;*.h;*.c</FilesToCopy>
 					<PreprocessorMacros>$$com.sysprogs.stm32.legacy_device_family$$</PreprocessorMacros>


### PR DESCRIPTION
This PR updates the recipe files to use the updated StdPeriph library available on the ST site. In my case I had to manually download the files as I did not manage to find if an automated script is available (like in **/fetch** command line option).